### PR TITLE
Fixing issue caused by failing template validator in 2.3.3

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -7,5 +7,5 @@
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::MODULE,
     'Emarsys_Emarsys',
-    isset($file) ? dirname($file) : __DIR__
+    __DIR__
 );


### PR DESCRIPTION
In 2.3.3 `\Magento\Framework\View\Element\Template\File\Validator`

We have `protected $_isAllowSymlinks = false;`

When running through `\Magento\Framework\View\Element\Template\File\Validator::isValid`

![image](https://user-images.githubusercontent.com/2239014/72408009-8c428780-37b5-11ea-80f4-43c95012f8eb.png)

We can see the path is not resolved into the full path (compared to other modules) and causing issue with the validator resulted in

```Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: '___/vendor/composer/../emarsys/emarsys/view/frontend/templates/emarsys/success.phtml' in module: 'Emarsys_Emarsys' block's name: 'emarsys.success'```